### PR TITLE
Fix imports for standalone memory benchmark scripts

### DIFF
--- a/benchmark/bloom_filter_memory.rb
+++ b/benchmark/bloom_filter_memory.rb
@@ -1,6 +1,6 @@
 require 'bundler/setup'
 require 'bloombroom'
-require 'benchmark/memory'
+require_relative 'memory'
 
 DEFAULT_M = 10000000
 DEFAULT_K = 1

--- a/benchmark/continuous_bloom_filter_memory.rb
+++ b/benchmark/continuous_bloom_filter_memory.rb
@@ -1,5 +1,5 @@
 require 'bundler/setup'
-require 'benchmark/memory'
+require_relative 'memory'
 require "bloombroom"
 
 DEFAULT_M = 10000000


### PR DESCRIPTION
Minor import issue I ran into when playing with the provided benchmark scripts.
