### PR TITLE
fixed some tests using be_false / be_true instead of be false / be true

### DIFF
--- a/spec/bloombroom/bits/bit_field_spec.rb
+++ b/spec/bloombroom/bits/bit_field_spec.rb
@@ -7,47 +7,47 @@ describe Bloombroom::BitField do
     bf = Bloombroom::BitField.new(100)
     (0..99).each do |i|
       bf[i].should == 0
-      bf.include?(i).should be_false
+      bf.include?(i).should be false
     end
   end
 
   it "should set and unset" do
     bf = Bloombroom::BitField.new(1000)
     bf[100].should == 0
-    bf.include?(100).should be_false
+    bf.include?(100).should be false
     bf[101].should == 0
-    bf.include?(101).should be_false
+    bf.include?(101).should be false
 
     bf[100] = 1
     bf[100].should == 1
-    bf.include?(100).should be_true
+    bf.include?(100).should be true
     bf[100] = 0
     bf[100].should == 0
-    bf.include?(100).should be_false
+    bf.include?(100).should be false
 
     bf.set(101)
     bf[101].should == 1
-    bf.include?(101).should be_true
+    bf.include?(101).should be true
     bf.unset(101)
     bf[101].should == 0
-    bf.include?(101).should be_false
+    bf.include?(101).should be false
   end
 
   it "should unset" do
     bf = Bloombroom::BitField.new(100)
-    (0..99).each{|i| bf.include?(i).should be_false}
+    (0..99).each{|i| bf.include?(i).should be false}
     (0..31).each{|i| bf.unset(i)}
-    (0..99).each{|i| bf.include?(i).should be_false}
-    
+    (0..99).each{|i| bf.include?(i).should be false}
+
     (0..31).each{|i| bf.set(i)}
-    (0..31).each{|i| bf.include?(i).should be_true}
-    (32..99).each{|i| bf.include?(i).should be_false}
+    (0..31).each{|i| bf.include?(i).should be true}
+    (32..99).each{|i| bf.include?(i).should be false}
 
     unsetbits = [0, 5, 6, 10, 16, 23, 31]
     unsetbits.each{|i| bf.unset(i)}
-    ((0..31).map{|i| i} - unsetbits).each{|i| bf.include?(i).should be_true}
-    unsetbits.each{|i| bf.include?(i).should be_false}
-    (32..99).each{|i| bf.include?(i).should be_false}
+    ((0..31).map{|i| i} - unsetbits).each{|i| bf.include?(i).should be true}
+    unsetbits.each{|i| bf.include?(i).should be false}
+    (32..99).each{|i| bf.include?(i).should be false}
   end
 
   it "should randomly set and unset" do
@@ -56,16 +56,16 @@ describe Bloombroom::BitField do
     other_bits = (0..999).map{|i| i} - random_bits
 
     random_bits.each{|i| bf.set(i)}
-    other_bits.each{|i| bf.include?(i).should be_false}
-    random_bits.each{|i| bf.include?(i).should be_true}
+    other_bits.each{|i| bf.include?(i).should be false}
+    random_bits.each{|i| bf.include?(i).should be true}
 
     other_bits.each{|i| bf.unset(i)}
-    other_bits.each{|i| bf.include?(i).should be_false}
-    random_bits.each{|i| bf.include?(i).should be_true}
+    other_bits.each{|i| bf.include?(i).should be false}
+    random_bits.each{|i| bf.include?(i).should be true}
 
     random_bits.each{|i| bf.unset(i)}
-    other_bits.each{|i| bf.include?(i).should be_false}
-    random_bits.each{|i| bf.include?(i).should be_false}
+    other_bits.each{|i| bf.include?(i).should be false}
+    random_bits.each{|i| bf.include?(i).should be false}
   end
 
   it "should randomly set and unset and support zero?" do
@@ -74,16 +74,16 @@ describe Bloombroom::BitField do
     other_bits = (0..999).map{|i| i} - random_bits
 
     random_bits.each{|i| bf.set(i)}
-    other_bits.each{|i| bf.zero?(i).should be_true}
-    random_bits.each{|i| bf.zero?(i).should be_false}
+    other_bits.each{|i| bf.zero?(i).should be true}
+    random_bits.each{|i| bf.zero?(i).should be false}
 
     other_bits.each{|i| bf.unset(i)}
-    other_bits.each{|i| bf.zero?(i).should be_true}
-    random_bits.each{|i| bf.zero?(i).should be_false}
+    other_bits.each{|i| bf.zero?(i).should be true}
+    random_bits.each{|i| bf.zero?(i).should be false}
 
     random_bits.each{|i| bf.unset(i)}
-    other_bits.each{|i| bf.zero?(i).should be_true}
-    random_bits.each{|i| bf.zero?(i).should be_true}
+    other_bits.each{|i| bf.zero?(i).should be true}
+    random_bits.each{|i| bf.zero?(i).should be true}
   end
 
   it "should report size" do

--- a/spec/bloombroom/filter/bloom_filter_spec.rb
+++ b/spec/bloombroom/filter/bloom_filter_spec.rb
@@ -5,24 +5,24 @@ describe Bloombroom::BloomFilter do
 
   it "should add" do
     bf = Bloombroom::BloomFilter.new(1000, 5)
-    bf.include?("abc1").should be_false
-    bf.include?("abc2").should be_false
-    bf.include?("abc3").should be_false
+    bf.include?("abc1").should be false
+    bf.include?("abc2").should be false
+    bf.include?("abc3").should be false
 
     bf.add("abc1")
-    bf.include?("abc1").should be_true
-    bf.include?("abc2").should be_false
-    bf.include?("abc3").should be_false
+    bf.include?("abc1").should be true
+    bf.include?("abc2").should be false
+    bf.include?("abc3").should be false
 
     bf.add("abc2")
-    bf.include?("abc1").should be_true
-    bf.include?("abc2").should be_true
-    bf.include?("abc3").should be_false
+    bf.include?("abc1").should be true
+    bf.include?("abc2").should be true
+    bf.include?("abc3").should be false
 
     bf.add("abc3")
-    bf.include?("abc1").should be_true
-    bf.include?("abc2").should be_true
-    bf.include?("abc3").should be_true
+    bf.include?("abc1").should be true
+    bf.include?("abc2").should be true
+    bf.include?("abc3").should be true
   end
 
   it "should keep track of size" do

--- a/spec/bloombroom/filter/continuous_bloom_filter_spec.rb
+++ b/spec/bloombroom/filter/continuous_bloom_filter_spec.rb
@@ -6,24 +6,24 @@ describe Bloombroom::ContinuousBloomFilter do
 
   it "should add" do
     bf = Bloombroom::ContinuousBloomFilter.new(*Bloombroom::BloomHelper.find_m_k(10, 0.001), 0)
-    bf.include?("abc1").should be_false
-    bf.include?("abc2").should be_false
-    bf.include?("abc3").should be_false
+    bf.include?("abc1").should be false
+    bf.include?("abc2").should be false
+    bf.include?("abc3").should be false
 
     bf.add("abc1")
-    bf.include?("abc1").should be_true
-    bf.include?("abc2").should be_false
-    bf.include?("abc3").should be_false
+    bf.include?("abc1").should be true
+    bf.include?("abc2").should be false
+    bf.include?("abc3").should be false
 
     bf.add("abc2")
-    bf.include?("abc1").should be_true
-    bf.include?("abc2").should be_true
-    bf.include?("abc3").should be_false
+    bf.include?("abc1").should be true
+    bf.include?("abc2").should be true
+    bf.include?("abc3").should be false
 
     bf.add("abc3")
-    bf.include?("abc1").should be_true
-    bf.include?("abc2").should be_true
-    bf.include?("abc3").should be_true
+    bf.include?("abc1").should be true
+    bf.include?("abc2").should be true
+    bf.include?("abc3").should be true
   end
 
   it "should find m and k" do
@@ -35,43 +35,43 @@ describe Bloombroom::ContinuousBloomFilter do
   it "should expire" do
     bf = Bloombroom::ContinuousBloomFilter.new(*Bloombroom::BloomHelper.find_m_k(100, 0.001), 0)
     bf.add("abc1")
-    bf.include?("abc1").should be_true
+    bf.include?("abc1").should be true
 
     bf.inc_time_slot
     bf.add("abc2")
-    bf.include?("abc1").should be_true
-    bf.include?("abc2").should be_true
-    
+    bf.include?("abc1").should be true
+    bf.include?("abc2").should be true
+
     bf.inc_time_slot
     bf.add("abc3")
-    bf.include?("abc1").should be_true
-    bf.include?("abc2").should be_true
-    bf.include?("abc3").should be_true
+    bf.include?("abc1").should be true
+    bf.include?("abc2").should be true
+    bf.include?("abc3").should be true
 
     bf.inc_time_slot
     bf.add("abc4")
-    bf.include?("abc1").should be_false
-    bf.include?("abc2").should be_true
-    bf.include?("abc3").should be_true
-    bf.include?("abc4").should be_true
+    bf.include?("abc1").should be false
+    bf.include?("abc2").should be true
+    bf.include?("abc3").should be true
+    bf.include?("abc4").should be true
 
     bf.inc_time_slot
-    bf.include?("abc1").should be_false
-    bf.include?("abc2").should be_false
-    bf.include?("abc3").should be_true
-    bf.include?("abc4").should be_true
+    bf.include?("abc1").should be false
+    bf.include?("abc2").should be false
+    bf.include?("abc3").should be true
+    bf.include?("abc4").should be true
 
     bf.inc_time_slot
-    bf.include?("abc1").should be_false
-    bf.include?("abc2").should be_false
-    bf.include?("abc3").should be_false
-    bf.include?("abc4").should be_true
+    bf.include?("abc1").should be false
+    bf.include?("abc2").should be false
+    bf.include?("abc3").should be false
+    bf.include?("abc4").should be true
 
     bf.inc_time_slot
-    bf.include?("abc1").should be_false
-    bf.include?("abc2").should be_false
-    bf.include?("abc3").should be_false
-    bf.include?("abc4").should be_false
+    bf.include?("abc1").should be false
+    bf.include?("abc2").should be false
+    bf.include?("abc3").should be false
+    bf.include?("abc4").should be false
 
     bf = Bloombroom::ContinuousBloomFilter.new(*Bloombroom::BloomHelper.find_m_k(100, 0.1), 0)
     keys = []
@@ -81,8 +81,8 @@ describe Bloombroom::ContinuousBloomFilter do
       alive = keys[[keys.size - 3, 0].max, 3]
       expired = keys - alive
 
-      alive.each{|key| bf.include?(key).should be_true}
-      expired.each{|key| bf.include?(key).should be_false}
+      alive.each{|key| bf.include?(key).should be true}
+      expired.each{|key| bf.include?(key).should be false}
 
       bf.inc_time_slot
     end


### PR DESCRIPTION
Hello,

This PR fixes some tests for newer rubies / rspec by using `be false` instead of `be_false` and `be true` instead of `be_true`

I still got 4 spec failing (using ruby 2.7.1 on Mac):

```
Failures:

  1) Bloombroom::FNVFFI should generate fnv1_32
     Failure/Error: Bloombroom::FNVFFI.fnv1_32(k).should == v

       expected: 99318309
            got: 3823118551 (using ==)
     # ./spec/bloombroom/hash/ffi_fnv_spec.rb:9:in `block (3 levels) in <top (required)>'
     # ./spec/bloombroom/hash/ffi_fnv_spec.rb:8:in `each'
     # ./spec/bloombroom/hash/ffi_fnv_spec.rb:8:in `block (2 levels) in <top (required)>'

  2) Bloombroom::FNVFFI should generate fnv1a_32
     Failure/Error: Bloombroom::FNVFFI.fnv1a_32(k).should == v

       expected: 182779749
            got: 344985583 (using ==)
     # ./spec/bloombroom/hash/ffi_fnv_spec.rb:15:in `block (3 levels) in <top (required)>'
     # ./spec/bloombroom/hash/ffi_fnv_spec.rb:14:in `each'
     # ./spec/bloombroom/hash/ffi_fnv_spec.rb:14:in `block (2 levels) in <top (required)>'

  3) Bloombroom::FNVFFI should generate fnv1_64
     Failure/Error: Bloombroom::FNVFFI.fnv1_64(k).should == v

       expected: 17000360259377273861
            got: 12371854390482265911 (using ==)
     # ./spec/bloombroom/hash/ffi_fnv_spec.rb:21:in `block (3 levels) in <top (required)>'
     # ./spec/bloombroom/hash/ffi_fnv_spec.rb:20:in `each'
     # ./spec/bloombroom/hash/ffi_fnv_spec.rb:20:in `block (2 levels) in <top (required)>'

  4) Bloombroom::FNVFFI should generate fnv1a_64
     Failure/Error: Bloombroom::FNVFFI.fnv1a_64(k).should == v

       expected: 10481507673508951749
            got: 1936705574634818255 (using ==)
     # ./spec/bloombroom/hash/ffi_fnv_spec.rb:27:in `block (3 levels) in <top (required)>'
     # ./spec/bloombroom/hash/ffi_fnv_spec.rb:26:in `each'
     # ./spec/bloombroom/hash/ffi_fnv_spec.rb:26:in `block (2 levels) in <top (required)>'

Deprecation Warnings:

Using `should` from rspec-expectations' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` with `config.expect_with(:rspec) { |c| c.syntax = :should }` instead. Called from /Users/korrigan/dev/quanta/bloombroom/spec/bloombroom/bits/bit_bucket_field_spec.rb:9:in `block (3 levels) in <top (required)>'.


If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace.

1 deprecation warning total

Finished in 0.07627 seconds (files took 0.14334 seconds to load)
27 examples, 4 failures

Failed examples:

rspec ./spec/bloombroom/hash/ffi_fnv_spec.rb:7 # Bloombroom::FNVFFI should generate fnv1_32
rspec ./spec/bloombroom/hash/ffi_fnv_spec.rb:13 # Bloombroom::FNVFFI should generate fnv1a_32
rspec ./spec/bloombroom/hash/ffi_fnv_spec.rb:19 # Bloombroom::FNVFFI should generate fnv1_64
rspec ./spec/bloombroom/hash/ffi_fnv_spec.rb:25 # Bloombroom::FNVFFI should generate fnv1a_64
```
