### PR TITLE
Serialization support

### DIFF
--- a/lib/bloombroom/filter/bloom_filter.rb
+++ b/lib/bloombroom/filter/bloom_filter.rb
@@ -5,8 +5,8 @@ require 'bloombroom/filter/bloom_helper'
 module Bloombroom
 
   # BloomFilter false positive probability rule of thumb: see http://www.igvita.com/2008/12/27/scalable-datasets-bloom-filters-in-ruby/
-  # a Bloom filter with a 1% error rate and an optimal value for k only needs 9.6 bits per key, and each time we add 4.8 bits 
-  # per element we decrease the error rate by ten times. 
+  # a Bloom filter with a 1% error rate and an optimal value for k only needs 9.6 bits per key, and each time we add 4.8 bits
+  # per element we decrease the error rate by ten times.
   #
   # 10000 elements, 1% error rate: m = 10000 * 10 bits -> 12k of memory, k = 0.7 * (10000 * 10 bits / 10000) = 7 hash functions
   # 10000 elements, 0.1% error rate: m = 10000 * 15 bits -> 18k of memory, k = 0.7 * (10000 * 15 bits / 10000) = 11 hash functions
@@ -18,13 +18,21 @@ module Bloombroom
 
     # @param m [Fixnum] filter size in bits
     # @param k [Fixnum] number of hashing functions
-    def initialize(m, k)
-      @bits = BitField.new(m)
+    # @param bytes [String] raw bits as a string obtained using {BitField.to_bytes}
+    # @param size [Integer] the size of the filter contained in bytes
+    def self.from_bytes m, k, bytes, size=0
+      new m, k, BitField.from_bytes(m, bytes), size
+    end
+
+    # @param m [Fixnum] filter size in bits
+    # @param k [Fixnum] number of hashing functions
+    def initialize(m, k, bits=nil, size=0)
+      @bits = bits || BitField.new(m)
       @m = m
       @k = k
-      @size = 0
+      @size = size
     end
-    
+
     # @param key [String] the key to add in the filter
     # @return [Fixnum] the total number of keys in the filter
     def add(key)
@@ -32,7 +40,7 @@ module Bloombroom
       @size += 1
     end
     alias_method :<<, :add
-    
+
     # @param key [String] test for the inclusion if key in the filter
     # @return [Boolean] true if given key is present in the filter. false positive are possible and dependant on the m and k filter parameters.
     def include?(key)
@@ -40,6 +48,6 @@ module Bloombroom
       true
     end
     alias_method :[], :include?
-    
+
   end
 end

--- a/spec/bloombroom/bits/bit_field_spec.rb
+++ b/spec/bloombroom/bits/bit_field_spec.rb
@@ -38,7 +38,7 @@ describe Bloombroom::BitField do
     (0..99).each{|i| bf.include?(i).should be_false}
     (0..31).each{|i| bf.unset(i)}
     (0..99).each{|i| bf.include?(i).should be_false}
-    
+
     (0..31).each{|i| bf.set(i)}
     (0..31).each{|i| bf.include?(i).should be_true}
     (32..99).each{|i| bf.include?(i).should be_false}
@@ -96,6 +96,27 @@ describe Bloombroom::BitField do
     bf[1] = 1
     bf[5] = 1
     bf.to_s.should == "0100010000"
+  end
+
+  it 'should produce raw bytes using #to_bytes' do
+    bf = Bloombroom::BitField.new(10)
+    bf[1] = 1
+    bf[5] = 1
+    bf.to_bytes.should == "\"\x00\x00\x00"
+  end
+
+  it 'should be restored using .from_bytes' do
+    bf = Bloombroom::BitField.from_bytes 10, "\"\x00\x00\x00"
+    bf[0].should == 0
+    bf[1].should == 1
+    bf[2].should == 0
+    bf[3].should == 0
+    bf[4].should == 0
+    bf[5].should == 1
+    bf[6].should == 0
+    bf[7].should == 0
+    bf[8].should == 0
+    bf[9].should == 0
   end
 
   it "should report total_set" do

--- a/spec/bloombroom/filter/bloom_filter_spec.rb
+++ b/spec/bloombroom/filter/bloom_filter_spec.rb
@@ -40,4 +40,16 @@ describe Bloombroom::BloomFilter do
     bf.k.should == 10
   end
 
+  it "should be (de)serializable using #bits.to_bytes and .from_bytes" do
+    bf = Bloombroom::BloomFilter.new 1000, 5
+    bf.add("abc1")
+    bf.add("abc2")
+    new_bf = Bloombroom::BloomFilter.from_bytes 1000, 5, bf.bits.to_bytes, bf.size
+    new_bf.m.should == bf.m
+    new_bf.k.should == bf.k
+    new_bf.size.should == bf.size
+    new_bf.include?('abc1').should be true
+    new_bf.include?('abc2').should be true
+    new_bf.include?('abc3').should be false
+  end
 end


### PR DESCRIPTION
Added serialization support by adding `BloomFilter.from_bytes` method as well as `BitField#to_bytes`.
So we can dump a bloomfilter data/options to any format we want using serialized data generated by `Bitfield#to_bytes` and deserialize it later.